### PR TITLE
Add calendar view

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,21 @@ A simple Flutter app for managing daily personal tasks with calendar integration
 
 ## ✨ Features
 
-- ✅ Add, edit, and delete tasks
+- ✅ Add , edit , and delete tasks
 - ✅ Mark tasks as completed
-- ✅ Display task list on Home screen
+- ✅ Display task list on Home view
 - ✅ Reactive state updates using GetX
 - ✅ Local storage using Hive
 - ✅ Clean project structure (MVC + Bindings)
+- ✅ Have custom widgets for reusable UI parts
+- ✅ Have Calendar view with task filtering by Date
 
 ## 🛠 Tech Stack
 
 - Flutter 3.8.1
 - GetX (state management + routing)
 - Hive (local database)
-
+- Table Calendar
 
 ## 🚀 Getting Started
 
@@ -24,3 +26,34 @@ A simple Flutter app for managing daily personal tasks with calendar integration
 flutter pub get
 flutter pub run build_runner build --delete-conflicting-outputs
 flutter run
+```
+
+# แอปจัดการงานส่วนตัว
+
+แอป Flutter แบบง่ายๆสำหรับจัดการงานส่วนตัวประจำวันรวมกับปฏิทิน
+
+## ✨ ฟังก์ชันการทำงาน
+
+- ✅ เพิ่ม , แก้ไข และ ลบงานได้
+- ✅ ทำเครื่องหมายเมื่องานเสร็จเรียบร้อย
+- ✅ แสดงรายการ งาน ในหน้าหน้าแรก
+- ✅ อัพเดทสถานะโดยใช้ Getx
+- ✅ จัดเก็บข้อมูลภายในโดยใช้ Hive
+- ✅ โครงสร้างโปรเจกต์ที่เป็นระเบียบ (MVC + Bindings)
+- ✅ มีวิดเจ็ตที่สร้างเอง สำหรับใช้ซ้ำในส่วนของ UI
+- ✅ มีหน้าปฏิทินที่สามารถกรองงานตามวันที่ได้
+
+## 🛠 เทคโนโลยีที่ใช้ในการพัฒนา
+
+- Flutter 3.8.1
+- GetX (state management + routing)
+- Hive (local database)
+- Table Calendar
+
+## 🚀 เริ่มต้นใช้งาน
+
+```bash
+flutter pub get
+flutter pub run build_runner build --delete-conflicting-outputs
+flutter run
+```

--- a/lib/src/bindings/calendar_table/calendat_table.dart
+++ b/lib/src/bindings/calendar_table/calendat_table.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import 'package:personal_task_manager_app/src/controllers/export_controllers.dart';
+
+class CalendarBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => TaskController());
+  }
+}

--- a/lib/src/bindings/calendar_table/export_calendat_table.dart
+++ b/lib/src/bindings/calendar_table/export_calendat_table.dart
@@ -1,0 +1,1 @@
+export 'calendat_table.dart';

--- a/lib/src/bindings/export_bindings.dart
+++ b/lib/src/bindings/export_bindings.dart
@@ -1,2 +1,3 @@
 export 'home/export_home_binding.dart';
 export 'add_task/export_add_task_binding.dart';
+export 'calendar_table/export_calendat_table.dart';

--- a/lib/src/config/export_config.dart
+++ b/lib/src/config/export_config.dart
@@ -4,3 +4,9 @@ export 'pub.dart';
 // * Hive
 export 'package:hive/hive.dart';
 export 'package:hive_flutter/hive_flutter.dart';
+
+// * Flutter Toast
+export 'package:fluttertoast/fluttertoast.dart';
+
+// * Smooth Page Indicator
+export 'package:smooth_page_indicator/smooth_page_indicator.dart';

--- a/lib/src/config/pub.dart
+++ b/lib/src/config/pub.dart
@@ -2,3 +2,4 @@ export 'dart:io';
 export 'dart:async';
 export 'dart:convert';
 export 'package:flutter/material.dart';
+export 'package:table_calendar/table_calendar.dart';

--- a/lib/src/controllers/calenda_table/calendar_table.dart
+++ b/lib/src/controllers/calenda_table/calendar_table.dart
@@ -1,0 +1,3 @@
+import 'package:get/get.dart';
+
+class CalendarTableController extends GetxController {}

--- a/lib/src/controllers/calenda_table/export_calendar_table.dart
+++ b/lib/src/controllers/calenda_table/export_calendar_table.dart
@@ -1,0 +1,1 @@
+export 'calendar_table.dart';

--- a/lib/src/controllers/export_controllers.dart
+++ b/lib/src/controllers/export_controllers.dart
@@ -1,2 +1,3 @@
 export 'task/export_task_controllers.dart';
 export 'add_task/export_add_task_controller.dart';
+export 'calenda_table/export_calendar_table.dart';

--- a/lib/src/controllers/task/task_controllers.dart
+++ b/lib/src/controllers/task/task_controllers.dart
@@ -5,6 +5,8 @@ import 'package:get/get.dart';
 class TaskController extends GetxController {
   var taskList = <TaskModel>[].obs;
   late Box<TaskModel> taskBox;
+  final Rx<DateTime> selectedDate = DateTime.now().obs;
+  final calendarFormat = CalendarFormat.month.obs;
 
   @override
   void onInit() {

--- a/lib/src/core/utils/colors.dart
+++ b/lib/src/core/utils/colors.dart
@@ -1,0 +1,1 @@
+class MyColors {}

--- a/lib/src/core/utils/constants.dart
+++ b/lib/src/core/utils/constants.dart
@@ -1,0 +1,140 @@
+// void showMessage(String message) {
+//   Fluttertoast.showToast(
+//     msg: message,
+//     backgroundColor: Colors.red,
+//     textColor: Colors.white,
+//     fontSize: 16,
+//     timeInSecForIosWeb: 4,
+//     gravity: ToastGravity.TOP,
+//   );
+// }
+
+import 'package:personal_task_manager_app/src/config/export_config.dart';
+
+void showLoaderDialog(BuildContext context) {
+  showDialog(
+    barrierDismissible: false,
+    context: context,
+    builder: (BuildContext context) {
+      return WillPopScope(
+        onWillPop: () async => false,
+        child: const AlertDialog(
+          content: SizedBox(
+            width: 100,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                CircularProgressIndicator(color: Colors.red),
+                SizedBox(height: 18),
+                Text("Loading..."),
+              ],
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}
+
+// showLoaderDialog(BuildContext context) {
+//   AlertDialog alert = AlertDialog(
+//     content: Builder(
+//       builder: (context) {
+//         return SizedBox(
+//           width: 100,
+//           child: Column(
+//             mainAxisSize: MainAxisSize.min,
+//             children: [
+//               const CircularProgressIndicator(
+//                 color: Colors.red,
+//               ),
+//               const SizedBox(height: 18),
+//               Container(
+//                 margin: const EdgeInsets.only(left: 7),
+//                 child: const Text("Loading..."),
+//               ),
+//             ],
+//           ),
+//         );
+//       },
+//     ),
+//   );
+//   showDialog(
+//     barrierDismissible: false,
+//     context: context,
+//     builder: (BuildContext context) {
+//       return alert;
+//     },
+//   );
+// }
+
+String getMessageFormErrorCode(String errorCode) {
+  switch (errorCode) {
+    case "ERROR_EMAIL_ALREADY_IN_USE":
+      return "Email already used. Go to login page.";
+    case "account-exists-with-different-credential":
+      return "Email already used. Go to login page.";
+    case "email-already-in-use":
+      return "Email already used. Go to login page.";
+    case "ERROR_WRONG_PASSWORD":
+    case "wrong-password":
+      return "Wrong Password";
+    case "ERROR_USER_NOT_FOUND":
+      return "No user found with this email.";
+    case "user-not-found":
+      return "No user found with this email.";
+    case "ERROR_USER_DISABLED":
+      return "User disabled.";
+    case "user-disabled":
+      return "User disabled";
+    case "ERROR_TOO_MANY_REQUEST":
+      return "Too many requests to log into this account.";
+    case "operation-not-allowed":
+      return "Too many requests to log into this account.";
+    case "ERROR_OPERATION_NOT_ALLOWED":
+      return "Too many requests to log into this account.";
+    case "ERROR_INVALID_EMAIL":
+      return "Email address is invalid";
+    case "invalid-email":
+      return "Email address is invalid";
+    default:
+      return "Login failed. Please try again.";
+  }
+}
+
+// bool loginValidation(String email, String password) {
+//   if (email.isEmpty && password.isEmpty) {
+//     showMessage("All Fields are empty");
+//   } else if (email.isEmpty) {
+//     showMessage("Email is Empty");
+//     return false;
+//   } else if (password.isEmpty) {
+//     showMessage("Password is Empty");
+//     return false;
+//   } else {
+//     return true;
+//   }
+//   return false;
+// }
+
+// bool singUpValidation(
+//     String email, String password, String name, String phone) {
+//   if (email.isEmpty && password.isEmpty && name.isEmpty && phone.isEmpty) {
+//     showMessage("All Fields are empty");
+//   } else if (name.isEmpty) {
+//     showMessage("Name is Empty");
+//     return false;
+//   } else if (email.isEmpty) {
+//     showMessage("Email is Empty");
+//     return false;
+//   } else if (phone.isEmpty) {
+//     showMessage("Phone is Empty");
+//     return false;
+//   } else if (password.isEmpty) {
+//     showMessage("Password is Empty");
+//     return false;
+//   } else {
+//     return true;
+//   }
+//   return false;
+// }

--- a/lib/src/core/utils/icons.dart
+++ b/lib/src/core/utils/icons.dart
@@ -1,0 +1,1 @@
+class MyIcons {}

--- a/lib/src/core/utils/media_queery.dart
+++ b/lib/src/core/utils/media_queery.dart
@@ -1,0 +1,11 @@
+import 'package:personal_task_manager_app/src/config/export_config.dart';
+
+class ScreenUtil {
+  static double screenWidth(BuildContext context) {
+    return MediaQuery.of(context).size.width;
+  }
+
+  static double screenHeight(BuildContext context) {
+    return MediaQuery.of(context).size.height;
+  }
+}

--- a/lib/src/core/widgets/custom_smooth_indicator/custom_smooth_indicator.dart
+++ b/lib/src/core/widgets/custom_smooth_indicator/custom_smooth_indicator.dart
@@ -1,0 +1,24 @@
+import 'package:personal_task_manager_app/src/config/export_config.dart';
+
+class CustomSmoothIndicator extends StatelessWidget {
+  final int activeIndex;
+  final int countImage;
+  const CustomSmoothIndicator({
+    super.key,
+    required this.activeIndex,
+    required this.countImage,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSmoothIndicator(
+      activeIndex: activeIndex,
+      count: countImage,
+      effect: const WormEffect(
+        dotHeight: 12,
+        dotWidth: 12,
+        activeDotColor: Colors.red,
+      ),
+    );
+  }
+}

--- a/lib/src/core/widgets/custom_smooth_indicator/export_custom_smooth_indicator.dart
+++ b/lib/src/core/widgets/custom_smooth_indicator/export_custom_smooth_indicator.dart
@@ -1,0 +1,1 @@
+export 'custom_smooth_indicator.dart';

--- a/lib/src/core/widgets/custom_text/custom_text.dart
+++ b/lib/src/core/widgets/custom_text/custom_text.dart
@@ -1,0 +1,48 @@
+import 'package:personal_task_manager_app/src/config/export_config.dart';
+
+class CustomText extends StatelessWidget {
+  final String text;
+  final Color? color;
+  final double? fontSize;
+  final FontWeight? fontWeight;
+  final TextDecoration? decoration;
+  final TextAlign? textAlign;
+  final int? maxLine;
+  final TextOverflow? overflow;
+  final FontStyle? fontStyle;
+  final String? fontFamily;
+  final double? height;
+  const CustomText(
+    this.text, {
+    super.key,
+    this.color,
+    this.fontSize,
+    this.fontWeight,
+    this.decoration,
+    this.textAlign,
+    this.maxLine,
+    this.overflow,
+    this.fontStyle,
+    this.fontFamily,
+    this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign ?? TextAlign.left,
+      maxLines: maxLine,
+      overflow: overflow ?? TextOverflow.ellipsis,
+      style: TextStyle(
+        fontFamily: fontFamily,
+        decoration: decoration ?? TextDecoration.none,
+        color: color ?? Colors.black,
+        fontSize: fontSize ?? 14,
+        fontWeight: fontWeight ?? FontWeight.w500,
+        fontStyle: fontStyle,
+        height: height,
+      ),
+    );
+  }
+}

--- a/lib/src/core/widgets/custom_text/export_custom_text.dart
+++ b/lib/src/core/widgets/custom_text/export_custom_text.dart
@@ -1,0 +1,1 @@
+export 'custom_text.dart';

--- a/lib/src/core/widgets/export_widgets.dart
+++ b/lib/src/core/widgets/export_widgets.dart
@@ -1,0 +1,3 @@
+export 'custom_text/export_custom_text.dart';
+export 'custom_smooth_indicator/export_custom_smooth_indicator.dart';
+export 'my_button/export_my_button.dart';

--- a/lib/src/core/widgets/my_button/export_my_button.dart
+++ b/lib/src/core/widgets/my_button/export_my_button.dart
@@ -1,0 +1,1 @@
+export 'my_button.dart';

--- a/lib/src/core/widgets/my_button/my_button.dart
+++ b/lib/src/core/widgets/my_button/my_button.dart
@@ -1,0 +1,30 @@
+import 'package:personal_task_manager_app/src/config/export_config.dart';
+import 'package:personal_task_manager_app/src/core/utils/media_queery.dart';
+import 'package:personal_task_manager_app/src/core/widgets/export_widgets.dart';
+
+class MyButton extends StatelessWidget {
+  final void Function() onPressed;
+  final String name;
+
+  const MyButton({super.key, required this.onPressed, required this.name});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 0),
+      child: SizedBox(
+        height: ScreenUtil.screenHeight(context) / 20,
+        width: double.infinity,
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+          ),
+          onPressed: onPressed,
+          child: CustomText(name, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/routes/pages_routes.dart
+++ b/lib/src/routes/pages_routes.dart
@@ -16,5 +16,10 @@ class PagesRoutes {
       page: () => AddTaskView(),
       binding: AddTaskBinding(),
     ),
+    GetPage(
+      name: PathRoutes.calendarTable,
+      page: () => CalendarTable(),
+      binding: CalendarBinding(),
+    ),
   ];
 }

--- a/lib/src/routes/path_routes.dart
+++ b/lib/src/routes/path_routes.dart
@@ -2,4 +2,5 @@ abstract class PathRoutes {
   // static const splash = '/splash';
   static const home = '/home';
   static const addTask = '/add-task';
+  static const calendarTable = '/calendar-table';
 }

--- a/lib/src/views/add_task/add_task_view.dart
+++ b/lib/src/views/add_task/add_task_view.dart
@@ -1,6 +1,7 @@
 import 'package:get/get.dart';
 import 'package:personal_task_manager_app/src/config/export_config.dart';
 import 'package:personal_task_manager_app/src/controllers/export_controllers.dart';
+import 'package:personal_task_manager_app/src/core/widgets/export_widgets.dart';
 
 class AddTaskView extends GetView<AddTaskController> {
   const AddTaskView({super.key});
@@ -8,7 +9,7 @@ class AddTaskView extends GetView<AddTaskController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('เพิ่มงานใหม่')),
+      appBar: AppBar(title: const CustomText('Add New Task', fontSize: 18)),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
@@ -33,24 +34,21 @@ class AddTaskView extends GetView<AddTaskController> {
             Obx(
               () => Row(
                 children: [
-                  const Text('วันที่:'),
-                  const SizedBox(width: 12),
-                  Text(
+                  const CustomText('วันที่ :', fontSize: 14),
+                  const SizedBox(width: 8),
+                  CustomText(
                     '${controller.selectedDate.value.toLocal()}'.split(' ')[0],
                   ),
                   const Spacer(),
                   TextButton(
                     onPressed: () => controller.pickDate(context),
-                    child: const Text('เลือกวันที่'),
+                    child: const CustomText('เลือกวันที่'),
                   ),
                 ],
               ),
             ),
             const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: controller.saveTask,
-              child: const Text('บันทึก'),
-            ),
+            MyButton(onPressed: controller.saveTask, name: 'บันทึก'),
           ],
         ),
       ),

--- a/lib/src/views/calendar_table/calendar_table.dart
+++ b/lib/src/views/calendar_table/calendar_table.dart
@@ -1,0 +1,84 @@
+import 'package:get/get.dart';
+import 'package:personal_task_manager_app/src/config/export_config.dart';
+import 'package:personal_task_manager_app/src/controllers/export_controllers.dart';
+import 'package:personal_task_manager_app/src/core/widgets/export_widgets.dart';
+
+class CalendarTable extends GetView<TaskController> {
+  const CalendarTable({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const CustomText('CalenDar Table', fontSize: 18),
+        centerTitle: true,
+      ),
+      body: Column(
+        children: [
+          Obx(() {
+            return TableCalendar(
+              firstDay: DateTime.utc(2020, 1, 1),
+              lastDay: DateTime.utc(2100, 12, 31),
+              focusedDay: controller.selectedDate.value,
+              selectedDayPredicate: (day) =>
+                  isSameDay(day, controller.selectedDate.value),
+              onDaySelected: (selectedDay, focusedDay) {
+                controller.selectedDate.value = selectedDay;
+              },
+              calendarFormat: CalendarFormat.month,
+              onFormatChanged: (_) {},
+              headerStyle: const HeaderStyle(formatButtonVisible: false),
+              calendarStyle: const CalendarStyle(
+                todayDecoration: BoxDecoration(
+                  color: Colors.blue,
+                  shape: BoxShape.circle,
+                ),
+                selectedDecoration: BoxDecoration(
+                  color: Colors.orange,
+                  shape: BoxShape.circle,
+                ),
+              ),
+            );
+          }),
+          const SizedBox(height: 16),
+          const Divider(),
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 8),
+            child: CustomText(
+              'Tasks for selected date',
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          Obx(() {
+            final tasks = controller.taskList
+                .where(
+                  (task) => isSameDay(task.date, controller.selectedDate.value),
+                )
+                .toList();
+            if (tasks.isEmpty) {
+              return const CustomText("No tasks for this day", fontSize: 14);
+            }
+            return Expanded(
+              child: ListView.builder(
+                itemCount: tasks.length,
+                itemBuilder: (_, index) {
+                  final task = tasks[index];
+                  return ListTile(
+                    leading: Icon(
+                      task.isDone
+                          ? Icons.check_circle
+                          : Icons.radio_button_unchecked,
+                    ),
+                    title: CustomText(task.title, fontSize: 14),
+                    subtitle: CustomText(task.description, fontSize: 14),
+                  );
+                },
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/views/calendar_table/export_calendar_view.dart
+++ b/lib/src/views/calendar_table/export_calendar_view.dart
@@ -1,0 +1,1 @@
+export 'calendar_table.dart';

--- a/lib/src/views/export_views.dart
+++ b/lib/src/views/export_views.dart
@@ -1,2 +1,3 @@
 export 'home/export_home_view.dart';
 export 'add_task/export_add_task_view.dart';
+export 'calendar_table/export_calendar_view.dart';

--- a/lib/src/views/home/home_view.dart
+++ b/lib/src/views/home/home_view.dart
@@ -1,6 +1,7 @@
 import 'package:get/get.dart';
 import 'package:personal_task_manager_app/src/config/export_config.dart';
 import 'package:personal_task_manager_app/src/controllers/export_controllers.dart';
+import 'package:personal_task_manager_app/src/core/widgets/export_widgets.dart';
 import 'package:personal_task_manager_app/src/models/export_model.dart';
 import 'package:personal_task_manager_app/src/routes/export_routes.dart';
 
@@ -10,7 +11,16 @@ class HomeView extends GetView<TaskController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('📋 My Tasks'), centerTitle: true),
+      appBar: AppBar(
+        title: const CustomText('My Tasks', fontSize: 18),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.calendar_today),
+            onPressed: () => Get.toNamed(PathRoutes.calendarTable),
+          ),
+        ],
+      ),
       body: Obx(() {
         final tasks = controller.taskList;
         if (tasks.isEmpty) {
@@ -24,21 +34,20 @@ class HomeView extends GetView<TaskController> {
             return Card(
               margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               child: ListTile(
-                title: Text(
+                title: CustomText(
                   task.title,
-                  style: TextStyle(
-                    decoration: task.isDone ? TextDecoration.lineThrough : null,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  decoration: task.isDone ? TextDecoration.lineThrough : null,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
                 ),
                 subtitle: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(task.description),
+                    CustomText(task.description, fontWeight: FontWeight.w400),
                     const SizedBox(height: 4),
-                    Text(
-                      '📅 ${task.date.toLocal().toString().split(' ')[0]}',
-                      style: const TextStyle(color: Colors.grey),
+                    CustomText(
+                      'วันที่ : ${task.date.toLocal().toString().split(' ')[0]}',
+                      color: Colors.grey,
                     ),
                   ],
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,8 @@ dependencies:
   path_provider: ^2.1.5
   table_calendar: ^3.2.0
   intl: ^0.20.2
+  smooth_page_indicator: ^1.2.1
+  fluttertoast: ^8.2.12
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Add-Calendar-View
- Added CalendarTable screen using table_calendar
- Connected to TaskController to filter tasks by selected date
- Handled UI state with GetX Obx
- Hid calendar format button for cleaner UI
- Create a folder named core to store widgets, utils, and other shared files.
- Create custom widgets for reusable UI parts.
- Create utility files to store things like colors, constants, and media query helpers.
- Add the libraries smooth_page_indicator and fluttertoast for future use.
- Edit Readme.md